### PR TITLE
Improve logging for workflow scripts

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -27,10 +27,14 @@ jobs:
         # CLI で取得した PR 情報を Markdown にまとめる
         env:
           GH_TOKEN: ${{ secrets.GH_PROJECT_PAT }}
+          LOG_LEVEL: INFO
+          LOGIN_USERS_B64: "eyJsb2dpblVzZXJzIjogW3sibG9naW5Vc2VyIjogImljaGktM2hFRyIsICJvcmdhbml6YXRpb24iOiAieW9ndXJ0In0sIHsibG9naW5Vc2VyIjogImljaGk3OTAxIiwgIm9yZ2FuaXphdGlvbiI6ICJjb3JpYW5kZXIifV19"
         run: |
           ls -l .github/workflows/script/
           python .github/workflows/script/collect_pr_status.py wiki
       - name: update-wiki
         # Wiki のチェックアウトが成功したときのみ更新を実行
         if: steps.checkout-wiki.outcome == 'success'
+        env:
+          LOG_LEVEL: INFO
         run: python .github/workflows/script/update_wiki.py wiki

--- a/.github/workflows/script/SPEC.md
+++ b/.github/workflows/script/SPEC.md
@@ -1,13 +1,21 @@
 # スクリプト仕様書
 
+## pr-check.yaml
+- `collect_pr_status.py` と `update_wiki.py` を実行する GitHub Actions ワークフロー。
+- 環境変数 `LOGIN_USERS_B64` にレビュワーと所属組織の対応表を Base64 文字列として設定する。
+- 環境変数 `LOG_LEVEL` を指定してスクリプトのログレベルを制御する。
+
 ## collect_pr_status.py
 - GitHub CLI (`gh`) を利用してオープン中の PR 情報と Projects (v2) のフィールド値を取得する。
-- レビュワーごとの最新ステータスを集計し、再依頼されたレビューは「保留」に戻す。
+- レビュー履歴を `submittedAt` で昇順ソートし、再依頼されたレビューは「保留」に戻す。
 - 取得した情報を `PR_Status.md` として Markdown 形式で出力する。
-- 出力する列: PR, Title, 状態, Reviewers, Assignees, Status, Priority, Target Date, Sprint。
+- 環境変数 `LOGIN_USERS_B64` を Base64 デコードしてユーザーと所属組織の対応表を作成し、レビュワーを組織ごとに分類する。リストに存在しないユーザーは `other` として扱う。
+- 出力する列: PR, Title, 状態, Assignees, Status, Priority, Target Date, Sprint、および各組織ごとの Reviewers 列。
+- `LOG_LEVEL` 環境変数を利用して logging モジュールの出力レベルを制御する。
 - 事前に `gh` コマンドが利用可能であること。
 
 ## update_wiki.py
 - 指定された Wiki リポジトリに移動し、`PR_Status.md` の変更をコミットしてプッシュする。
 - `GITHUB_TOKEN` を用いた認証 URL に差し替えることで push を可能にする。
 - 差分がない場合はコミットやプッシュを行わず終了する。
+- `LOG_LEVEL` 環境変数を利用して logging モジュールの出力レベルを制御する。

--- a/.github/workflows/script/collect_pr_status.py
+++ b/.github/workflows/script/collect_pr_status.py
@@ -14,7 +14,17 @@ import datetime
 import json
 import os
 import subprocess
+import logging
+import base64
 from typing import List, Dict, Any
+
+# 環境変数 LOG_LEVEL を参照してログレベルを設定
+LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO").upper()
+logging.basicConfig(
+    level=getattr(logging, LOG_LEVEL, logging.INFO),
+    format="%(levelname)s: %(message)s",
+)
+logger = logging.getLogger(__name__)
 
 def determine_pr_status(reviews: List[Dict[str, Any]], is_draft: bool) -> str:
     """レビュー結果から PR のステータス文字列を判定する
@@ -54,7 +64,7 @@ def run_gh(args: List[str]) -> str:
     if result.returncode != 0:
         # エラー出力があれば優先して表示し、なければ標準出力を表示する
         err_msg = (result.stderr or result.stdout).strip()
-        print(f"gh command failed: {err_msg}")
+        logger.error(f"gh command failed: {err_msg}")
         raise subprocess.CalledProcessError(
             result.returncode, args, output=result.stdout, stderr=result.stderr
         )
@@ -100,33 +110,66 @@ def extract_fields(project_json: Dict[str, Any], fields: List[str]) -> Dict[str,
 def main(output_dir: str) -> None:
     os.makedirs(output_dir, exist_ok=True)
     output_file = os.path.join(output_dir, "PR_Status.md")
+
+    # 環境変数 LOGIN_USERS_B64 をデコードしてユーザーと組織の対応表を作成
+    login_user_map: Dict[str, str] = {}
+    org_order: List[str] = []
+    encoded = os.environ.get("LOGIN_USERS_B64")
+    if encoded:
+        try:
+            decoded = base64.b64decode(encoded).decode()
+            login_users_json = json.loads(decoded)
+            for item in login_users_json.get("loginUsers", []):
+                login = item.get("loginUser")
+                org = item.get("organization")
+                if login and org:
+                    login_user_map[login] = org
+                    if org not in org_order:
+                        org_order.append(org)
+        except Exception as e:
+            # デコードや JSON パースに失敗した場合はログに記録して空のマッピングを利用する
+            logger.error(f"LOGIN_USERS_B64 decode failed: {e}")
+    else:
+        logger.warning("LOGIN_USERS_B64 is not set")
+
+    # Markdown のヘッダを動的に生成する
+    reviewer_cols = [f"{org} Reviewers" for org in org_order + ["other"]]
+    header_cols = [
+        "PR",
+        "Title",
+        "状態",
+        *reviewer_cols,
+        "Assignees",
+        "Status",
+        "Priority",
+        "Target Date",
+        "Sprint",
+    ]
     with open(output_file, "w", encoding="utf-8") as f:
         f.write("# Pull Request Status\n\n")
         f.write(f"Updated: {datetime.datetime.now():%Y-%m-%d %H:%M:%S}\n\n")
-        f.write(
-            "| PR | Title | 状態 | Reviewers | Assignees | Status | Priority | Target Date | Sprint |\n"
-        )
-        f.write(
-            "| --- | ----- | ---- | --------- | --------- | ------ | -------- | ----------- | ------ |\n"
-        )
+        f.write("| " + " | ".join(header_cols) + " |\n")
+        f.write("| " + " | ".join(["---"] * len(header_cols)) + " |\n")
 
     # 1. オープン中の PR 一覧を取得
+    #    number や title などの基本情報をまとめて JSON 形式で取得する
     pr_list_json = run_gh([
         "gh", "pr", "list", "--state", "open", "--limit", "100",
         "--json", "number,title,author,createdAt,updatedAt,url,isDraft",
     ])
-    print(f"PR_LIST={pr_list_json}")
+    logger.debug(f"PR_LIST={pr_list_json}")
     pr_list = json.loads(pr_list_json)
 
     for pr in pr_list:
         # 2. PR 詳細を取得
+        #    レビュー履歴(reviews)、レビュー依頼(reviewRequests)、アサイン(assignees)を取得する
         number = pr["number"]
         title = pr["title"].replace("\n", " ").replace("|", "\\|")
         url = pr["url"]
         is_draft = pr.get("isDraft", False)
 
         details_json = run_gh(["gh", "pr", "view", str(number), "--json", "reviews,reviewRequests,assignees"])
-        print(f"DETAILS for PR {number}={details_json}")
+        logger.debug(f"DETAILS for PR {number}={details_json}")
         details = json.loads(details_json)
         reviews = details.get("reviews", [])
         requested = [r["login"] for r in details.get("reviewRequests", [])]
@@ -135,32 +178,41 @@ def main(output_dir: str) -> None:
 
         # レビュワーごとの最新ステータスを保持する辞書
         reviewer_states = {r: "PENDING" for r in requested}
-        for r in reviews:
+        # submittedAt で昇順に並べ替えて最新レビューを反映する
+        sorted_reviews = sorted(
+            reviews, key=lambda x: x.get("submittedAt", "")
+        )
+        for r in sorted_reviews:
             author = r.get("author")
             if not author:
                 continue
             login = author.get("login")
             if not login:
                 continue
-            # レビュー再依頼中であれば過去の結果を無視する
-            if login in reviewer_states:
+            # 現在レビュー再依頼中のレビュワーは保留状態のままにする
+            if login in requested:
                 continue
             # 同一レビュワーが複数回レビューした場合は最後の状態を採用する
             reviewer_states[login] = r.get("state", "")
-
-        reviewer_info_list = [
-            format_reviewer_status(reviewer, state)
-            for reviewer, state in reviewer_states.items()
-        ]
-        reviewer_info = "<br>".join(reviewer_info_list) if reviewer_info_list else "未割当"
+        # 組織ごとにレビュワーを分類し各列に表示する文字列を生成する
+        org_groups: Dict[str, List[str]] = {org: [] for org in org_order}
+        org_groups["other"] = []
+        for reviewer, state in reviewer_states.items():
+            org = login_user_map.get(reviewer, "other")
+            org_groups.setdefault(org, []).append(
+                format_reviewer_status(reviewer, state)
+            )
 
         pr_status = determine_pr_status(reviews, is_draft)
 
         # 3. Projects (v2) のフィールド値を GraphQL で取得
+        #    まず gh pr view で PR の node ID を取得する
         pr_node_id = run_gh(["gh", "pr", "view", str(number), "--json", "id", "-q", ".id"]).strip()
-        print(f"PR_NODE_ID for PR {number}={pr_node_id}")
+        logger.debug(f"PR_NODE_ID for PR {number}={pr_node_id}")
 
         # プロジェクトアイテムに紐付く任意フィールドを取得するクエリ
+        # PullRequest の projectItems から fieldValues を列挙し、
+        # 各フィールド型ごとに name/text/date などの値を取り出す
         graphql_query = (
             "query($PR_NODE_ID: ID!) {\n"
             "  node(id: $PR_NODE_ID) {\n"
@@ -202,12 +254,13 @@ def main(output_dir: str) -> None:
             "  }\n"
             "}\n"
         )
+        # 上記クエリを gh api graphql で実行してフィールド値を取得する
         try:
             project_json_str = run_gh([
                 "gh", "api", "graphql",
                 "-f", f"query={graphql_query}", "-f", f"PR_NODE_ID={pr_node_id}",
             ])
-            print(f"PROJECT_JSON for PR {number}={project_json_str}")
+            logger.debug(f"PROJECT_JSON for PR {number}={project_json_str}")
             project_json = json.loads(project_json_str)
             field_names = [
                 "Status",
@@ -222,21 +275,30 @@ def main(output_dir: str) -> None:
             sprint = field_values["Sprint"]
         except subprocess.CalledProcessError as e:
             # gh コマンドが失敗した場合はエラーメッセージを出力し、値を "-" とする
-            print(f"PROJECT_JSON fetch failed for PR {number}: {e.stderr}")
+            logger.error(f"PROJECT_JSON fetch failed for PR {number}: {e.stderr}")
             status = priority = target_date = sprint = "-"
         except json.JSONDecodeError as e:
             # JSON パースに失敗した場合も値を "-" とする
-            print(f"PROJECT_JSON parse failed for PR {number}: {e}")
+            logger.error(f"PROJECT_JSON parse failed for PR {number}: {e}")
             status = priority = target_date = sprint = "-"
 
-        row = (
-            f"| #{number} | [{title}]({url}) | {pr_status} | {reviewer_info} | {assignees_str} | "
-            f"{status} | {priority} | {target_date} | {sprint} |\n"
+        # Markdown 出力用の行を組み立てる
+        row_fields: List[str] = [
+            f"#{number}",
+            f"[{title}]({url})",
+            pr_status,
+        ]
+        for org in org_order + ["other"]:
+            names = org_groups.get(org)
+            row_fields.append(" ".join(names) if names else "-")
+        row_fields.extend(
+            [assignees_str, status, priority, target_date, sprint]
         )
+        row = "| " + " | ".join(row_fields) + " |\n"
         with open(output_file, "a", encoding="utf-8") as f:
             f.write(row)
 
-    print(f"PR 情報を {output_file} に出力しました")
+    logger.info(f"PR 情報を {output_file} に出力しました")
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="PR 情報を収集して Markdown に出力します")

--- a/.github/workflows/script/update_wiki.py
+++ b/.github/workflows/script/update_wiki.py
@@ -8,6 +8,15 @@
 import os
 import subprocess
 import sys
+import logging
+
+# 環境変数 LOG_LEVEL を参照してログレベルを設定
+LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO").upper()
+logging.basicConfig(
+    level=getattr(logging, LOG_LEVEL, logging.INFO),
+    format="%(levelname)s: %(message)s",
+)
+logger = logging.getLogger(__name__)
 
 def run(cmd):
     """サブプロセスでコマンドを実行しエラー時には例外を送出する"""
@@ -29,7 +38,7 @@ def main(wiki_dir: str) -> None:
         ])
 
     if not os.path.exists("PR_Status.md"):
-        print("PR_Status.md が見つかりません")
+        logger.error("PR_Status.md が見つかりません")
         sys.exit(1)
 
     # 差分があればコミットしてプッシュする
@@ -42,10 +51,10 @@ def main(wiki_dir: str) -> None:
         run(["git", "commit", "-m", "Update PR status"])
         run(["git", "push"])
     else:
-        print("更新内容がないためコミットしません")
+        logger.info("更新内容がないためコミットしません")
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        print("Wiki リポジトリのパスを指定してください", file=sys.stderr)
+        logger.error("Wiki リポジトリのパスを指定してください")
         sys.exit(1)
     main(sys.argv[1])


### PR DESCRIPTION
## Summary
- add base64-encoded reviewer organization map to workflow env
- decode LOGIN_USERS_B64 and group reviewers by organization in PR status script
- split reviewer list into per-organization columns in PR status report
- sort review history chronologically and ignore re-requested reviewers so approved reviews display correctly
- add configurable logging via LOG_LEVEL for workflow scripts
- document workflow and script changes in SPEC

## Testing
- `python -m py_compile .github/workflows/script/collect_pr_status.py .github/workflows/script/update_wiki.py`
- `LOG_LEVEL=DEBUG python .github/workflows/script/update_wiki.py` *(fails: Wiki リポジトリのパスを指定してください)*
- `LOG_LEVEL=DEBUG LOGIN_USERS_B64="eyJsb2dpblVzZXJzIjogW3sibG9naW5Vc2VyIjogImljaGktM2hFRyIsICJvcmdhbml6YXRpb24iOiAieW9ndXJ0In0sIHsibG9naW5Vc2VyIjogImljaGk3OTAxIiwgIm9yZ2FuaXphdGlvbiI6ICJjb3JpYW5kZXIifV19" python .github/workflows/script/collect_pr_status.py` *(fails: [Errno 2] No such file or directory: 'gh')*

------
https://chatgpt.com/codex/tasks/task_e_68923a4aec608324a631513cc44e1838