### PR TITLE
Add debug output for decoded login users JSON

### DIFF
--- a/.github/workflows/script/collect_pr_status.py
+++ b/.github/workflows/script/collect_pr_status.py
@@ -129,6 +129,9 @@ def main(output_dir: str, repo: str = "") -> None:
         try:
             decoded = base64.b64decode(encoded).decode()
             login_users_json = json.loads(decoded)
+            logger.debug(
+                f"LOGIN_USERS_JSON={json.dumps(login_users_json, ensure_ascii=False)}"
+            )  # デコード結果を出力
             for item in login_users_json.get("loginUsers", []):
                 login = item.get("loginUser")
                 org = item.get("organization")


### PR DESCRIPTION
## Summary
- log decoded `LOGIN_USERS_B64` JSON contents for debugging

## Testing
- `LOG_LEVEL=DEBUG LOGIN_USERS_B64=$(python - <<'PY'
import base64,json;print(base64.b64encode(json.dumps({'loginUsers':[{'loginUser':'alice','organization':'org1'}]}).encode()).decode())
PY
) python .github/workflows/script/collect_pr_status.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c1b9cec508324be29792eeab43f8b