### PR TITLE
リポジトリ名に基づくPRステータスページの生成

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -14,6 +14,8 @@ jobs:
     permissions:
       contents: write
       pull-requests: read
+    env:
+      REPOSITORY_NAME: ${{ github.event.repository.name }} # Wiki ページ名に使用
     steps:
       - uses: actions/checkout@v4
       - id: checkout-wiki

--- a/.github/workflows/script/collect_pr_status.py
+++ b/.github/workflows/script/collect_pr_status.py
@@ -103,9 +103,13 @@ def extract_fields(project_json: Dict[str, Any], fields: List[str]) -> Dict[str,
 
 def main(output_dir: str) -> None:
     os.makedirs(output_dir, exist_ok=True)
-    output_file = os.path.join(output_dir, "PR_Status.md")
+    repo_name = os.environ.get("REPOSITORY_NAME")
+    if not repo_name:
+        repo_name = os.environ.get("GITHUB_REPOSITORY", "").split("/")[-1] or "repository"
+    # リポジトリ名を用いたファイル名を生成する
+    output_file = os.path.join(output_dir, f"{repo_name}_PR_status.md")
     with open(output_file, "w", encoding="utf-8") as f:
-        f.write("# Pull Request Status\n\n")
+        f.write(f"# {repo_name} PR Status\n\n")
         f.write(f"Updated: {datetime.datetime.now():%Y-%m-%d %H:%M:%S}\n\n")
         f.write(
             "| PR | Title | 状態 | Reviewers | Assignees | Status | Sub-issues progress | Priority | Size | Estimate | Start date | End date | Sprint |\n"

--- a/.github/workflows/script/update_wiki.py
+++ b/.github/workflows/script/update_wiki.py
@@ -2,7 +2,7 @@
 """PR 情報を記載した Markdown を Wiki リポジトリへ反映するスクリプト
 
 1. GitHub Actions から渡されたトークンを使って push 可能なリモート URL を設定
-2. `PR_Status.md` の変更をステージングし、差分があればコミット・プッシュ
+2. `<リポジトリ名>_PR_status.md` の変更をステージングし、差分があればコミット・プッシュ
 3. 変更がない場合は何もせず終了する
 """
 import os
@@ -28,18 +28,23 @@ def main(wiki_dir: str) -> None:
             f"https://x-access-token:{token}@github.com/{repo}.wiki.git",
         ])
 
-    if not os.path.exists("PR_Status.md"):
-        print("PR_Status.md が見つかりません")
+    repo_name = os.environ.get("REPOSITORY_NAME")
+    if not repo_name:
+        repo_name = os.environ.get("GITHUB_REPOSITORY", "").split("/")[-1] or "repository"
+    file_name = f"{repo_name}_PR_status.md"
+    # リポジトリ名を用いたファイルを確認しステージングする
+    if not os.path.exists(file_name):
+        print(f"{file_name} が見つかりません")
         sys.exit(1)
 
     # 差分があればコミットしてプッシュする
-    run(["git", "add", "PR_Status.md"])
+    run(["git", "add", file_name])
     diff = subprocess.run(["git", "diff", "--cached", "--quiet"])
     if diff.returncode != 0:
         actor = os.environ.get("GITHUB_ACTOR", "github-actions")
         run(["git", "config", "user.name", actor])
         run(["git", "config", "user.email", f"{actor}@users.noreply.github.com"])
-        run(["git", "commit", "-m", "Update PR status"])
+        run(["git", "commit", "-m", f"Update {repo_name} PR status"])
         run(["git", "push"])
     else:
         print("更新内容がないためコミットしません")


### PR DESCRIPTION
## Summary
- Wikiページをリポジトリ名_PR_status.mdとして出力
- 生成されたページをコミット・プッシュする際にリポジトリ名を利用
- ワークフローでリポジトリ名を環境変数として提供

## Testing
- `python -m py_compile .github/workflows/script/collect_pr_status.py .github/workflows/script/update_wiki.py`


------
https://chatgpt.com/codex/tasks/task_e_689c32d66b9c83249e574d6cc88160c5