### PR TITLE
Change PR status filename to use repository name

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -24,7 +24,7 @@ jobs:
           repository: ${{ github.repository }}.wiki
           path: wiki
       - name: pr-check
-        # CLI で取得した PR 情報を Markdown にまとめる
+        # CLI で取得した PR 情報を <リポジトリ名>_PR_status.md として Markdown にまとめる
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           LOG_LEVEL: DEBUG
@@ -34,7 +34,7 @@ jobs:
             r-toku/sandbox-repo
         run: |
           ls -l .github/workflows/script/
-          # メインリポジトリと複数のサブリポジトリの PR ステータスを収集
+          # メインリポジトリとサブリポジトリの PR ステータスを収集し *_PR_status.md を生成
           for repo in "${GITHUB_REPOSITORY}" $SUB_REPOSITORY; do
             [ -z "$repo" ] && continue
             python .github/workflows/script/collect_pr_status.py wiki --repo "$repo"

--- a/.github/workflows/script/SPEC.md
+++ b/.github/workflows/script/SPEC.md
@@ -8,17 +8,17 @@
 ## collect_pr_status.py
 - GitHub CLI (`gh`) を利用してオープン中の PR 情報と Projects (v2) のフィールド値を取得する。
 - レビュー履歴を `submittedAt` で昇順ソートし、再依頼されたレビューは「保留」に戻す。
-- 取得した情報を `PR_Status.md` として Markdown 形式で出力する。
+- 取得した情報を `<リポジトリ名>_PR_status.md` として Markdown 形式で出力する。
 - 環境変数 `LOGIN_USERS_B64` を Base64 デコードしてユーザーと所属組織の対応表を作成し、レビュワーを組織ごとに分類する。リストに存在しないユーザーは `other` として扱う。
 - 出力する列: PR, Title, 状態, Assignees, Status, Priority, Target Date, Sprint、および各組織ごとの Reviewers 列。
 - `LOG_LEVEL` 環境変数を利用して logging モジュールの出力レベルを制御する。
 - レビュワーごとの最新ステータスを集計し、再依頼されたレビューは「保留」に戻す。
-- `--repo` 引数で対象リポジトリを指定し、リポジトリごとに `PR_Status_<owner>_<repo>.md` を出力する。
+- `--repo` 引数で対象リポジトリを指定し、リポジトリごとに `<owner>_<repo>_PR_status.md` を出力する。
 - 出力する列: PR, Title, 状態, Reviewers, Assignees, Status, Priority, Target Date, Sprint。
 - 事前に `gh` コマンドが利用可能であること。
 
 ## update_wiki.py
-- 指定された Wiki リポジトリに移動し、`PR_Status*.md` の変更をコミットしてプッシュする。
+- 指定された Wiki リポジトリに移動し、`*_PR_status.md` の変更をコミットしてプッシュする。
 - `GITHUB_TOKEN` を用いた認証 URL に差し替えることで push を可能にする。
 - 差分がない場合はコミットやプッシュを行わず終了する。
 - `LOG_LEVEL` 環境変数を利用して logging モジュールの出力レベルを制御する。

--- a/.github/workflows/script/collect_pr_status.py
+++ b/.github/workflows/script/collect_pr_status.py
@@ -132,7 +132,8 @@ def main(output_dir: str, repo: str = "") -> None:
         repo = repo_env
         repo_arg = ["--repo", repo] if repo else []
         file_suffix = repo.replace("/", "_") if repo else "unknown"
-    output_file = os.path.join(output_dir, f"PR_Status_{file_suffix}.md")
+    # 出力ファイル名を <リポジトリ名>_PR_status.md 形式で生成
+    output_file = os.path.join(output_dir, f"{file_suffix}_PR_status.md")
 
     # 環境変数 LOGIN_USERS_B64 をデコードしてユーザーと組織の対応表を作成
     login_user_map: Dict[str, str] = {}

--- a/.github/workflows/script/update_wiki.py
+++ b/.github/workflows/script/update_wiki.py
@@ -2,7 +2,7 @@
 """PR 情報を記載した Markdown を Wiki リポジトリへ反映するスクリプト
 
 1. GitHub Actions から渡されたトークンを使って push 可能なリモート URL を設定
-2. `PR_Status*.md` の変更をステージングし、差分があればコミット・プッシュ
+2. `*_PR_status.md` の変更をステージングし、差分があればコミット・プッシュ
 3. 変更がない場合は何もせず終了する
 """
 import os
@@ -38,9 +38,10 @@ def main(wiki_dir: str) -> None:
             f"https://x-access-token:{token}@github.com/{repo}.wiki.git",
         ])
 
-    status_files = sorted(glob.glob("PR_Status*.md"))
+    # 新しい命名規則 <リポジトリ名>_PR_status.md に一致するファイルを検索
+    status_files = sorted(glob.glob("*_PR_status.md"))
     if not status_files:
-        logger.error("PR_Status*.md が見つかりません")
+        logger.error("*_PR_status.md が見つかりません")
         sys.exit(1)
 
     # 差分があればコミットしてプッシュする


### PR DESCRIPTION
## Summary
- update PR status scripts to output `<repository>_PR_status.md`
- adjust wiki update script and workflow comments for new naming
- revise SPEC documentation accordingly

## Testing
- `python -m py_compile .github/workflows/script/collect_pr_status.py .github/workflows/script/update_wiki.py && echo py_compile_ok`


------
https://chatgpt.com/codex/tasks/task_e_689c3528ee048324b6186f04f9c5e6fc