### PR TITLE
feat: sync PR project fields from linked issue

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -11,6 +11,8 @@ on:
 jobs:
   pr-check:
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GH_PROJECT_PAT }}
     permissions:
       contents: write
       pull-requests: read
@@ -26,7 +28,6 @@ jobs:
       - name: pr-check
         # CLI で取得した PR 情報を <リポジトリ名>_PR_status.md として Markdown にまとめる
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           LOG_LEVEL: DEBUG
           LOGIN_USERS_B64: ${{ vars.LOGIN_USERS_B64 }}
           # スペースや改行で区切って複数指定可能なサブリポジトリ一覧

--- a/.github/workflows/script/SPEC.md
+++ b/.github/workflows/script/SPEC.md
@@ -4,6 +4,7 @@
 - `collect_pr_status.py` と `update_wiki.py` を実行する GitHub Actions ワークフロー。
 - 環境変数 `LOGIN_USERS_B64` にレビュワーと所属組織の対応表を Base64 文字列として設定する。
 - 環境変数 `LOG_LEVEL` を指定してスクリプトのログレベルを制御する。
+- 全処理で `GH_TOKEN` に `GH_PROJECT_PAT` を設定し、Projects への書込み権限を利用する。
 
 ## collect_pr_status.py
 - GitHub CLI (`gh`) を利用してオープン中の PR 情報と Projects (v2) のフィールド値を取得する。
@@ -16,6 +17,11 @@
 - `--repo` 引数で対象リポジトリを指定し、リポジトリごとに `<owner>_<repo>_PR_status.md` を出力する。
 - 出力する列: PR, Title, 状態, Reviewers, Assignees, Status, Priority, Target Date, Sprint。
 - 事前に `gh` コマンドが利用可能であること。
+- PR の「Development」に紐づく最初の Issue を特定し、PR が参加している各 Project で以下を実行する。
+  - PR 側アイテムの Priority/Target Date/Sprint が空欄で Issue 側に値がある場合のみコピーする。
+  - Option 名や Iteration タイトルが一致しない場合は何もしない。
+  - PR が対象 Project に未参加の場合も何もしない。
+- PR の Assignees が空で Issue に Assignees がいる場合、同一ユーザーを PR に追加する。
 
 ## update_wiki.py
 - 指定された Wiki リポジトリに移動し、`*_PR_status.md` の変更をコミットしてプッシュする。


### PR DESCRIPTION
## Summary
- sync empty PR fields (Priority/Target Date/Sprint) from linked issue's project items
- copy assignees from issue when PR has none
- use GH_PROJECT_PAT for project updates

## Testing
- `python -m py_compile .github/workflows/script/collect_pr_status.py`
- `pip install pyyaml` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b0d139fc4c8324a44a82700dc6ddd6